### PR TITLE
fix: move Depends() to function signature to resolve AttributeError

### DIFF
--- a/app/api/v1/endpoints/otp.py
+++ b/app/api/v1/endpoints/otp.py
@@ -10,7 +10,7 @@ from app.services.rabbitmq import RabbitMQService
 router = APIRouter()
 
 @router.post("/generate-otp", status_code=status.HTTP_202_ACCEPTED)
-async def generate_otp_endpoint(payload: OTPRequest, r: Redis= Depends(get_redis)):
+async def generate_otp_endpoint(payload: OTPRequest, r: Redis= Depends(get_redis), mq_service: RabbitMQService = Depends(get_rabbitmq_service)):
     identifier = payload.email
     otp_code = generate_otp()
     hashed_otp = hash_otp(otp_code)
@@ -23,7 +23,6 @@ async def generate_otp_endpoint(payload: OTPRequest, r: Redis= Depends(get_redis
     # Publish OTP to RabbitMQ for asynchronous processing (e.g., sending email)
     # In a massive scale app, we might inject this service too, 
     # but instantiating it here is fine for now.
-    mq_service: RabbitMQService = Depends(get_rabbitmq_service)
     
     message = OTPMessage(
         email=identifier,


### PR DESCRIPTION
# fix: Resolve "Depends object has no attribute" error

## Description
This PR fixes a critical bug in the `/send-otp` endpoint where `Depends()` was being called inside the function body instead of in the function signature.

In FastAPI, `Depends` is a marker that must be used as a default value for a function parameter. Calling it inside the body returns the `Depends` object itself, not the result of the dependency, causing the `AttributeError: 'Depends' object has no attribute 'publish_otp'`.

## Key Changes
- **Refactor `/send-otp`:** Moved the `mq_service` dependency injection from the function body to the function arguments.

## Error Fixed
Messaging error: 'Depends' object has no attribute 'publish_otp'

## Testing
- [x] Confirmed that `mq_service` is now correctly instantiated as `RabbitMQService` instead of a `Depends` object.
- [x] `/send-otp` endpoint successfully publishes messages without crashing.