### PR TITLE
feat: add OTP verification endpoint with hash comparison

### DIFF
--- a/app/schemas/otp.py
+++ b/app/schemas/otp.py
@@ -1,16 +1,16 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 class OTPRequest(BaseModel):
     email: EmailStr
 
 class OTPVerify(BaseModel):
     email: EmailStr
-    otp: str
+    otp_code: str = Field(..., min_length=6, max_length=6, pattern=r"^\d+$")
 
 class OTPMessage(BaseModel):
     """
     The shape of the payload we send to RabbitMQ.
     """
     email: EmailStr
-    otp_code: str  # The plain text code (so the worker can email it)
+    otp_code: str   # The plain text code (so the worker can email it)
     ttl: int


### PR DESCRIPTION
# feat: Add OTP verification endpoint

## Description
This PR implements the second half of the OTP flow: **Verification**. It adds a new endpoint `/verify-otp` that allows users to submit their email and the OTP code they received. The system hashes the input code and compares it against the secure hash stored in Redis.

This PR Closes issue #5 
## Key Changes

### 🔒 Security & Logic
- **Hash Comparison:** The endpoint hashes the incoming OTP code using the same algorithm as the generator (`hash_otp`) to ensure we never store or compare raw OTPs.
- **One-Time Use:** Upon successful verification, the Redis key is immediately deleted to prevent replay attacks (using the same OTP twice).
- **String Validation:** Updated `OTPVerify` schema to strictly enforce that the OTP is a 6-digit string of numbers (`^\d{6}$`), preventing type coercion attacks.

### 📡 New Endpoint
- `POST /api/v1/otp/verify-otp`
    - **Input:** `{ "email": "user@example.com", "otp_code": "123456" }`
    - **Success:** `200 OK` (OTP is valid)
    - **Failure:** `400 Bad Request` (Invalid code or Expired)

## Testing Checklist
- [x] **Happy Path:** Send OTP -> Receive code (mock logs) -> Verify code -> Returns Success.
- [x] **Replay Attack:** Verify the same code twice -> Second attempt fails (Key deleted).
- [x] **Tampering:** Change one digit of the OTP -> Returns "Invalid OTP code".
- [x] **Expiration:** Wait 5 minutes (or manually delete Redis key) -> Returns "OTP expired".